### PR TITLE
Update integration table to now show SW 2.1 and also add ability to use Spark 2.1, which will call SW 2.1 if user does not set specific version.

### DIFF
--- a/R/install_h2o.R
+++ b/R/install_h2o.R
@@ -4,17 +4,23 @@
 #' @export
 h2o_release_table <- function(){
   
+  #Spark 2.1
+  release_spark_2_1 <- data.frame(Spark_Version = c("2.1"), 
+                                Sparkling_Water_Version = rev(c("2.1.0")),
+                                H2O_Version = rev(c("3.10.3.2")),
+                                H2O_Release_Name = rev(c("rel-tverberg")),
+                                H2O_Release_Patch_Number = rev(c("2")))
   #Spark 2.0
   release_spark_2 <- data.frame(Spark_Version = c("2.0"), 
-                              Sparkling_Water_Version = rev(c("2.0.0","2.0.1","2.0.2","2.0.3", "2.0.4")),
-                              H2O_Version = rev(c("3.10.0.7","3.10.0.10","3.10.0.10","3.10.1.2", "3.10.3.2")),
-                              H2O_Release_Name = rev(c("rel-turing","rel-turing","rel-turing","rel-turnbull","rel-tverberg")),
-                              H2O_Release_Patch_Number = rev(c("7","10","10","2","2")))
+                              Sparkling_Water_Version = rev(c("2.0.0","2.0.1","2.0.2","2.0.3", "2.0.4","2.0.5")),
+                              H2O_Version = rev(c("3.10.0.7","3.10.0.10","3.10.0.10","3.10.1.2", "3.10.3.2","3.10.3.2")),
+                              H2O_Release_Name = rev(c("rel-turing","rel-turing","rel-turing","rel-turnbull","rel-tverberg","rel-tverberg")),
+                              H2O_Release_Patch_Number = rev(c("7","10","10","2","2","2")))
   #Spark 1.6
   release_spark_1_6 <- data.frame(Spark_Version = c("1.6"), 
                                 Sparkling_Water_Version = rev(c("1.6.1","1.6.2","1.6.3","1.6.4","1.6.5","1.6.6","1.6.7","1.6.8")),
                                 H2O_Version = rev(c("3.8.1.3","3.8.1.3","3.8.2.3","3.8.2.4","3.8.2.6","3.10.0.4","3.10.0.6","3.10.0.7")),
                                 H2O_Release_Name = rev(c("rel-turan","rel-turan","rel-turchin","rel-turchin","rel-turchin","rel-turing","rel-turing","rel-turing")),
                                 H2O_Release_Patch_Number = rev(c("3","3","3","4","6","4","6","7")))
-  return(rbind(release_spark_2,release_spark_1_6))
+  return(rbind(release_spark_2_1,release_spark_2,release_spark_1_6))
 }

--- a/R/package.R
+++ b/R/package.R
@@ -1,7 +1,7 @@
 #' @importFrom utils capture.output browseURL
 #' @importFrom sparklyr spark_dependency register_extension invoke_static invoke spark_connection spark_dataframe sdf_register spark_context
 #' @importFrom h2o h2o.getFrame h2o.getId h2o.init
-#' @importFrom utils read.table
+#' @importFrom utils read.table packageVersion
 NULL
 
 # Define required spark packages

--- a/R/package.R
+++ b/R/package.R
@@ -12,25 +12,41 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
   sw_location <- getOption("rsparkling.sparklingwater.location", default = NULL)
   
   #If sw_version & sw_location are not provided, then check the Spark installation
+  #If its Spark 2.1.*, then we fetch the latest Sparkling Water for Spark 2.1.*
   #If its Spark 2.0.*, then we fetch the latest Sparkling Water for Spark 2.0.*
   #If its Spark 1.6.*, then we fetch the latest Sparkling Water for Spark 1.6.*
   #If none of the above, then throw an exception
   #Also provide adequate version of H2O for latest Sparkling Water
   if (is.null(sw_version) && is.null(sw_location)) {
-    if (as.package_version(spark_version)$major == "2") {
+    if (as.package_version(spark_version)$major == "2" && as.package_version(spark_version)$minor == "1") {
+      #Get latest Sparkling Water release for Spark 2.1.*
+      latest <- read.table("http://s3.amazonaws.com/h2o-release/sparkling-water/rel-2.1/latest")
+      sw_version <- sprintf("2.1.%s",latest)
+      message(sprintf("Spark version %s detected. Will call latest Sparkling Water version %s",spark_version,sw_version))
+      if (packageVersion("h2o") != "3.10.3.2") {
+        message(paste0('\nDetected H2O version ', packageVersion("h2o"),'. Please install H2O version 3.10.3.2, which is compliant with the latest Sparkling Water version for Spark 2.1.* -> Sparkling Water version ', sw_version,'\n
+To update your h2o R package, copy/paste the following commands and then restart your R session:
+                       
+  detach("package:rsparkling", unload = TRUE)
+  if ("package:h2o" %in% search()) { detach("package:h2o", unload = TRUE) }
+  if (isNamespaceLoaded("h2o")){ unloadNamespace("h2o") }
+  remove.packages("h2o")
+  install.packages("h2o", type = "source", repos = "http://h2o-release.s3.amazonaws.com/h2o/rel-tverberg/2/R")\n'))
+      }
+    }else if (as.package_version(spark_version)$major == "2") {
       #Get latest Sparkling Water release for Spark 2.0.*
       latest <- read.table("http://s3.amazonaws.com/h2o-release/sparkling-water/rel-2.0/latest")
       sw_version <- sprintf("2.0.%s",latest)
       message(sprintf("Spark version %s detected. Will call latest Sparkling Water version %s",spark_version,sw_version))
-      if (packageVersion("h2o") != "3.10.1.2") {
-        message(paste0('\nDetected H2O version ', packageVersion("h2o"),'. Please install H2O version 3.10.1.2, which is compliant with the latest Sparkling Water version ', sw_version,'\n
+      if (packageVersion("h2o") != "3.10.3.2") {
+        message(paste0('\nDetected H2O version ', packageVersion("h2o"),'. Please install H2O version 3.10.3.2, which is compliant with the latest Sparkling Water version for Spark 2.0.* ->  Sparkling Water version ', sw_version,'\n
 To update your h2o R package, copy/paste the following commands and then restart your R session:
 
   detach("package:rsparkling", unload = TRUE)
   if ("package:h2o" %in% search()) { detach("package:h2o", unload = TRUE) }
   if (isNamespaceLoaded("h2o")){ unloadNamespace("h2o") }
   remove.packages("h2o")
-  install.packages("h2o", type = "source", repos = "http://h2o-release.s3.amazonaws.com/h2o/rel-turnbull/2/R")\n'))
+  install.packages("h2o", type = "source", repos = "http://h2o-release.s3.amazonaws.com/h2o/rel-tverberg/2/R")\n'))
       }
     } else if (as.package_version(spark_version)$major == "1" && as.package_version(spark_version)$minor == "6" ) { #Assuming Spark 1.6
       #Get latest Sparkling Water release for Spark 1.6.*
@@ -38,7 +54,7 @@ To update your h2o R package, copy/paste the following commands and then restart
       sw_version <- sprintf("1.6.%s",latest) 
       message(sprintf("Spark version %s detected. Will call latest Sparkling Water version %s",spark_version,sw_version))
       if (packageVersion("h2o") != "3.10.0.7"){
-        message(paste0('\nDetected H2O version ', packageVersion("h2o"),'. Please install H2O version 3.10.0.7, which is compliant with the latest Sparkling Water version ', sw_version,'\n
+        message(paste0('\nDetected H2O version ', packageVersion("h2o"),'. Please install H2O version 3.10.0.7, which is compliant with the latest Sparkling Water version for Spark 1.6.* ->  Sparkling Water version ', sw_version,'\n
 To update your h2o R package, copy/paste the following commands and then restart your R session:
 
   detach("package:rsparkling", unload = TRUE)
@@ -48,7 +64,7 @@ To update your h2o R package, copy/paste the following commands and then restart
   install.packages("h2o", type = "source", repos = "http://h2o-release.s3.amazonaws.com/h2o/rel-turing/7/R")\n'))
       }
     } else {
-      stop("Spark installation 1.6.* or 2.0.* are not detected. Please install Spark 2.0.* or 1.6.*")
+      stop("Spark installation 1.6.*, 2.0.*, or 2.1.* are not detected. Please install Spark 1.6.*, 2.0.*, or 2.1.*")
     }
   }
   

--- a/R/package.R
+++ b/R/package.R
@@ -1,7 +1,8 @@
 #' @importFrom utils capture.output browseURL
 #' @importFrom sparklyr spark_dependency register_extension invoke_static invoke spark_connection spark_dataframe sdf_register spark_context
 #' @importFrom h2o h2o.getFrame h2o.getId h2o.init
-#' @importFrom utils read.table packageVersion
+#' @importFrom utils read.table
+#' @importFrom utils packageVersion
 NULL
 
 # Define required spark packages

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ Advanced users may want to choose a particular Sparking Water / H2O version (spe
 
 | Spark Version | Sparkling Water Version | H2O Version | H2O Release Name | H2O Release Patch Number |
 | ------------- | ----------------------- | ----------- | ---------------- | ------------------ |
-| 2.0.*         | 2.0.4                   | 3.10.3.2    | "rel-tverberg"   |        "2"         |
+| 2.1.*         | 2.1.0                   | 3.10.3.2    | "rel-tverberg"   |        "2"         |
+|               |                         |             |                  |                    |
+| 2.0.*         | 2.0.5                   | 3.10.3.2    | "rel-tverberg"   |        "2"         |
+|               | 2.0.4                   | 3.10.3.2    | "rel-tverberg"   |        "2"         |
 |               | 2.0.3                   | 3.10.1.2    | "rel-turnbull"   |        "2"         |
 |               | 2.0.2                   | 3.10.0.10   | "rel-turing"     |        "10"        |
 |               | 2.0.1                   | 3.10.0.10   | "rel-turing"     |        "10"        |                  


### PR DESCRIPTION
This PR does a few things.

- Updates the rsparkling integration table to now show SW 2.1 
- Update the `install_h2o()` to reflect the new integration table 
- Adds the ability to use Spark 2.1, which will call SW 2.1 if user does not set specific version.
- Fix NAMESPACE issue with `packageVersion`