### PR TITLE
Update testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,10 @@ cache: packages
 
 r_github_packages:
   - hadley/devtools
+
 env:
-- NOT_CRAN="true"
+  global:
+   -  NOT_CRAN="true"
+  matrix:
+    - SPARKLINGWATER_VERSION="2.0.5"
+    - SPARKLINGWATER_VERSION="1.6.8"

--- a/tests/run-tests-local.sh
+++ b/tests/run-tests-local.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+#Run rsparkling unit tests locally
+run-tests () {
+    while [ "$#" -ne "0" ]; do
+	export SPARKLINGWATER_VERSION="$1"
+	echo "==> Running tests with Sparkling Water Version ${SPARKLINGWATER_VERSION} ..."
+	R -f testthat.R
+	shift
+    done
+}
+
+export NOT_CRAN="true"
+if [ "$#" -eq "0" ]; then
+    run-tests 2.0.5 1.6.8 #Insert more Sparkling Water versions here. Currently set to latest for Spark 2.0 and 1.6.
+else
+    run-tests "$@"
+fi

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -4,11 +4,22 @@ library(sparklyr)
 library(h2o)
 library(rsparkling)
 
-options(rsparkling.sparklingwater.version = Sys.getenv("SPARKLINGWATER_VERSION","1.6.7"),
-        rsparkling.spark.version =          Sys.getenv("SPARK_VERSION","1.6.2"))
+
+options(rsparkling.sparklingwater.version = Sys.getenv("SPARKLINGWATER_VERSION","2.0.5"))
+
+sw_version <- getOption("rsparkling.sparklingwater.version", default = NULL)
+
+if(as.package_version(sw_version)$major == "2" && as.package_version(sw_version)$minor == "1"){
+  options(rsparkling.spark.version =  "2.1.0") #Use latest Spark 2.1.*
+}else if(as.package_version(sw_version)$major == "2"){
+  options(rsparkling.spark.version =  "2.0.2") #Use latest Spark 2.0.*
+}else{
+  options(rsparkling.spark.version =  "1.6.2") #Use latest Spark 1.6.*
+}
 
 if(identical(Sys.getenv("NOT_CRAN"), "true")) { # testthat::skip_on_cran
+  cat(sprintf("Starting tests with Sparkling Water version: %s & Spark version: %s \n",Sys.getenv("SPARKLINGWATER_VERSION"),getOption("rsparkling.spark.version")))
   test_check("rsparkling")
-} else {
-  cat("Skipping tests\n")
+}else{
+  cat("Skipping Tests\n")
 }

--- a/tests/testthat/test_transforms.R
+++ b/tests/testthat/test_transforms.R
@@ -2,7 +2,7 @@
 context("Test transformations of H2O frames and Spark frames in rsparkling")
 
 test_that("Test transformation from h2o frame to data frame", {
-  sc <- spark_connect(master = "local[*]")
+  sc <- spark_connect(master = "local[*]",version=getOption("rsparkling.spark.version"))
   df <- as.data.frame(t(c(1,2,3,4,"A"))) # workaround for sparklyr#316
   sdf <- copy_to(sc, df)
   hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
@@ -14,7 +14,7 @@ test_that("Test transformation from h2o frame to data frame", {
 })
 
 test_that("Test transformation of a spark data_frame of bools to an h2o frame of bools", {
-  sc <- spark_connect(master = "local[*]")
+  sc <- spark_connect(master = "local[*]",version=getOption("rsparkling.spark.version"))
   df <- as.data.frame(t(c(TRUE,FALSE,TRUE,FALSE)))
   sdf <- copy_to(sc, df, overwrite = TRUE)
   hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
@@ -26,7 +26,7 @@ test_that("Test transformation of a spark data_frame of bools to an h2o frame of
 })
 
 test_that("Test transformation of a spark data_frame of complex types to an h2o frame of complex types", {
-  sc <- spark_connect(master = "local[*]")
+  sc <- spark_connect(master = "local[*]",version=getOption("rsparkling.spark.version"))
   n <- c(2)
   s <- c("aa")
   b <- c(TRUE)
@@ -40,7 +40,7 @@ test_that("Test transformation of a spark data_frame of complex types to an h2o 
 })
 
 test_that("Test transformation of a spark data_frame of float types to an h2o frame of floats", {
-  sc <- spark_connect(master = "local[*]")
+  sc <- spark_connect(master = "local[*]",version=getOption("rsparkling.spark.version"))
   df <- as.data.frame(t(c(1.5,1.3333333333,178.5555)))
   sdf <- copy_to(sc, df, overwrite = TRUE)
   hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
@@ -51,7 +51,7 @@ test_that("Test transformation of a spark data_frame of float types to an h2o fr
 })
 
 test_that("Test transformation of a spark data_frame of int types to an h2o frame of ints", {
-  sc <- spark_connect(master = "local[*]")
+  sc <- spark_connect(master = "local[*]",version=getOption("rsparkling.spark.version"))
   df <- as.data.frame(t(c(1,125,1778)))
   sdf <- copy_to(sc, df, overwrite = TRUE)
   hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
@@ -62,7 +62,7 @@ test_that("Test transformation of a spark data_frame of int types to an h2o fram
 })
 
 test_that("Test transformation of a spark data_frame of str types to an h2o frame of str", {
-  sc <- spark_connect(master = "local[*]")
+  sc <- spark_connect(master = "local[*]",version=getOption("rsparkling.spark.version"))
   df <- as.data.frame(t(c("A","B","C")))
   sdf <- copy_to(sc, df, overwrite = TRUE)
   hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
@@ -73,7 +73,7 @@ test_that("Test transformation of a spark data_frame of str types to an h2o fram
 })
 
 test_that("Test transformation from dataframe to h2o frame", {
-  sc <- spark_connect(master = "local[*]")
+  sc <- spark_connect(master = "local[*]",version=getOption("rsparkling.spark.version"))
   mtcars_tbl <- copy_to(sc, mtcars, overwrite = TRUE)
   mtcars_hf <- as_h2o_frame(sc, mtcars_tbl, strict_version_check=FALSE)
   
@@ -83,7 +83,7 @@ test_that("Test transformation from dataframe to h2o frame", {
 })
 
 test_that("Test transformation from dataframe to h2o frame", {
-  sc <- spark_connect(master = "local[*]")
+  sc <- spark_connect(master = "local[*]",version=getOption("rsparkling.spark.version"))
   mtcars_tbl <- copy_to(sc, mtcars, overwrite = TRUE)
   mtcars_hf_name <- as_h2o_frame(sc, mtcars_tbl, name = "frame1", strict_version_check=FALSE)
   


### PR DESCRIPTION
This PR does the following:

1. Runs a Travis job for SW 2.0.5 & SW 1.6.8
2. The version of Spark is chosen based on the major version of SW (i.e., SW 2.0.5 is tested with Spark 2.0.2, etc.)
3. Adds a shell script that allows unit tests to run locally with different version of Sparkling Water. Currently set to Sparkling Water 2.0.5 and 1.6.8.

The main benefit is that the testing infrastructure is a bit more modular and easier to deal with. 